### PR TITLE
Windows gnumake (a.k.a. make)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,3 +7,5 @@ if errorlevel 1 exit 1
 copy .\\GccRel\\gnumake.exe  %LIBRARY_BIN%\\gnumake.exe
 if errorlevel 1 exit 1
 
+copy .\\GccRel\\gnumake.exe  %LIBRARY_BIN%\\make.exe
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,9 @@ about:
   home: https://www.gnu.org/software/make/
   license: GPLv3
   license_file: COPYING
-  summary: "GNU Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files."
+  summary: >-
+    GNU Make is a tool which controls the generation of executables and other
+    non-source files of a program from the program's source files.
   doc_url: https://www.gnu.org/software/make/manual/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,6 @@ source:
 
 build:
   number: 1
-  force_ignore_keys:    # [win]
-    - c_compiler        # [win]
-    - m2w64_c_compiler  # [unix]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ test:
 about:
   home: https://www.gnu.org/software/make/
   license: GPLv3
+  license_file: COPYING
   summary: "GNU Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files."
   doc_url: https://www.gnu.org/software/make/manual/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ test:
   commands:
     - $PREFIX/bin/make --help  # [unix]
     - '"%LIBRARY_BIN%\gnumake.exe" --help'  # [win]
+    - '"%LIBRARY_BIN%\make.exe" --help'  # [win]
 
 about:
   home: https://www.gnu.org/software/make/


### PR DESCRIPTION
Install `gnumake.exe` as `make.exe` on Windows. Should make it a bit easier to get started with `make` on Windows without knowing the details of the package. A little bit of general tidying.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
