### PR TITLE
skip detecting binary files with prefix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2003
+  number: 2004
+  detect_binary_files_with_prefix: False
 
 requirements:
   build:


### PR DESCRIPTION
@jjhelmus and I had trouble getting make to work with aarch64/

Quoting Jonathan
> Prefix replacement in make's binaries causes issues. Disabling the replacement, as is done in #2, should fix the issue. I ran into similar issue with linux-ppc64le do not recall the full details.


xref: https://github.com/Archiconda/make-make-feedstock/issues/1
https://github.com/Archiconda/make-make-feedstock/pull/2

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
