### PR TITLE
Also provide mingw32-make.exe

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,3 +9,6 @@ if errorlevel 1 exit 1
 
 copy .\\GccRel\\gnumake.exe  %LIBRARY_BIN%\\make.exe
 if errorlevel 1 exit 1
+
+copy .\\GccRel\\gnumake.exe  %LIBRARY_BIN%\\mingw32-make.exe
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,10 @@ requirements:
 
 test:
   commands:
-    - $PREFIX/bin/make --help               # [unix]
-    - '%LIBRARY_BIN%\gnumake.exe --help'    # [win]
-    - '%LIBRARY_BIN%\make.exe --help'       # [win]
+    - $PREFIX/bin/make --help                  # [unix]
+    - '%LIBRARY_BIN%\gnumake.exe --help'       # [win]
+    - '%LIBRARY_BIN%\make.exe --help'          # [win]
+    - '%LIBRARY_BIN%\mingw32-make.exe --help'  # [win]
 
 about:
   home: https://www.gnu.org/software/make/


### PR DESCRIPTION
Some windows applications, on Windows, expect that `make` is provided as `mingw32-make.exe` under `bin` directory.

This PR is to also provide it, along with `make.exe`and `gnumake.exe`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
